### PR TITLE
Support for mySQL read

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ To run the program:
 or
 ```yarn```
 
-2. Usage `node index.js <path_to_team.csv_file> <path_to_scores.csv_file>`
+2. Usage `node index.js <path_to_team.csv_file> <path_to_scores.csv_file>` when reading from CSVs
+   `node index.js <path_to_team.csv_file> <path_to_scores.csv_file> --sql=<database name>` when reading from SQL tables.
 
 Outputs a teamScores.csv file to the current directory.
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ To run the program:
 or
 ```yarn```
 
-2. Usage `node index.js <path_to_team.csv_file> <path_to_scores.csv_file>` when reading from CSVs
-   `node index.js <path_to_team.csv_file> <path_to_scores.csv_file> --sql=<database name>` when reading from SQL tables.
+2. Usage `node index.js <path_to_team.csv_file> <path_to_scores.csv_file> [path_to_output_file.csv]` when reading from CSVs
+   `node index.js <teams_table> <scores_table> --sql=<database name> [path_to_output_file.csv]` when reading from SQL tables.
 
-Outputs a teamScores.csv file to the current directory.
+Outputs a teamScores.csv file to the current directory or to the file specified as the argument.
 
 ## Issues
 

--- a/eval_teamwise/eval_teamwise.js
+++ b/eval_teamwise/eval_teamwise.js
@@ -4,27 +4,27 @@ const output = require("../output");
 const _ = require('lodash');
 
 /*
-* The function takes necessary agruments:
-* scorescsv : The path to the csv file coresponding to the scores of students
+* The function takes necessary arguments:
+* scorescsv : The path to the csv file corresponding to the scores of students
 * teamcsv : The path to the csv file corresponding to the teams of the students
-* [teamScorescsv] :  An optional agrument specifying the path to the csv file to output evaluated marks
+* [teamScorescsv] :  An optional argument specifying the path to the csv file to output evaluated marks
 *
 * @author: Chaitanya Mukka
 *
 */
 
 
-var computeTeamResults = function(args) {
+var computeTeamResults = function(args, logger=console) {
     // Check if whether to read from SQL.
     const database = args.database
     if (typeof database !== 'undefined') {
-        promiseMarks = input.sqlContents(database, "scores")
-        promiseTeam = input.sqlContents(database, "team")
+        promiseMarks = input.sqlContents(database, args.scores)
+        promiseTeam = input.sqlContents(database, args.teams)
     }
     else {
         // promises which resolve to return contents parsed of the scorescsv file and teamcsv files
-        promiseMarks = input.csvContents(args.scorescsv);
-        promiseTeam = input.csvContents(args.teamcsv);
+        promiseMarks = input.csvContents(args.scores);
+        promiseTeam = input.csvContents(args.teams);
     }
     return Promise.all([promiseMarks, promiseTeam]).then(function(res) {
         // res contains the returns of all the promises in the order of as in the input array of promises
@@ -79,7 +79,7 @@ var computeTeamResults = function(args) {
         // TODO: log members those who don't have any assigned teams
         //logger.info(`No teams found for ${members}`);
         return output(finalMarks, args.teamScorescsv || "./teamScores.csv");
-    });
+    }).catch(err => { logger.error(err)});
 };
 
 module.exports = {

--- a/eval_teamwise/eval_teamwise.js
+++ b/eval_teamwise/eval_teamwise.js
@@ -14,7 +14,7 @@ const _ = require('lodash');
 */
 
 
-var computeTeamResults = function(args, logger=console) {
+var computeTeamResults = function(args) {
     // Check if whether to read from SQL.
     const database = args.database
     if (typeof database !== 'undefined') {
@@ -79,7 +79,7 @@ var computeTeamResults = function(args, logger=console) {
         // TODO: log members those who don't have any assigned teams
         //logger.info(`No teams found for ${members}`);
         return output(finalMarks, args.teamScorescsv || "./teamScores.csv");
-    }).catch(err => { logger.error(err)});
+    }).catch(err => { console.error(err)});
 };
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ const eval_teamwise = require("./eval_teamwise");
 prog
     .version("1.0.0")
     .description("Program to facilitate pairwise evaluation in CS F213 Labs")
-    .argument("<teamcsv>", "CSV Data for Teams")
-    .argument("<scorescsv>", "CSV Data for Scores")
+    .argument("<teams>", "Path to the CSV data file or the SQL table name(use --sql option) for Team data")
+    .argument("<scores>", "Path to the CSV data file or the SQL table name(use --sql option) for Scores data")
     .argument("[teamScorescsv]", "CSV file to store evaluations")
     .option('--sql <database>', prog.LIST)
     .action(function(args, options, logger) {

--- a/index.js
+++ b/index.js
@@ -10,8 +10,11 @@ prog
     .argument("<teamcsv>", "CSV Data for Teams")
     .argument("<scorescsv>", "CSV Data for Scores")
     .argument("[teamScorescsv]", "CSV file to store evaluations")
+    .option('--sql <database>', prog.LIST)
     .action(function(args, options, logger) {
-        eval_teamwise.writeResult(args,logger);
+        if(typeof options.sql !== 'undefined')
+            args.database = options.sql;
+        eval_teamwise.writeResult(args, logger);
     });
 
 prog.parse(process.argv);

--- a/input/input.js
+++ b/input/input.js
@@ -1,7 +1,9 @@
-const Promise = require('bluebird');
-const parser = require('./csvParse');
-const mysql = require('mysql');
-const readFile = Promise.promisify(require('fs').readFile);
+const Promise = require("bluebird");
+const parser = require("./csvParse");
+
+const _ = require("lodash");
+const mysql = require("mysql");
+const readFile = Promise.promisify(require("fs").readFile);
 
 /*
 * Function fileContents reads the contents of a csv file and parses it
@@ -9,47 +11,39 @@ const readFile = Promise.promisify(require('fs').readFile);
 */
 
 var fileContents = function(file) {
-
-	return readFile(file,'utf8').then(function(content) {
-		return new parser(content);
-	});
+    return readFile(file, "utf8").then(function(content) {
+        return new parser(content);
+    });
 };
 
-
 var sqlRead = function(database, table) {
-    return new Promise(function(resolve, reject) {
-        var link = mysql.createConnection({
-                        host:'localhost',
-                        port:'3306',
-                        user:'root',
-                        password:'root',
-                        database:database
-                   });
-        link.connect(function(error){
-                     if(error){
-                        console.log(error);
-                     }});
-        link.query("SELECT * FROM "+table, function(err, rows, fields){
-            objs = []
-            if(rows.length !== 0){
-                for(var i = 0;i < rows.length;i++)
-                {
-                    if(table === 'team')
-                        objs.push([rows[i].studentID, rows[i].teamID])
-                    else
-                        objs.push([rows[i].studentID, rows[i].score])
-                }
-                resolve(objs);
+    var link = Promise.promisifyAll(
+        mysql.createConnection({
+            host: "localhost",
+            port: "3306",
+            user: "root",
+            database: database  
+        })
+    );
+    var content = [];
+    return link.queryAsync("SELECT * FROM " + table)
+        .then(function(rows, fields) {
+            if (rows.length !== 0) {
+                content = _.map(rows, function(row) {
+                    return _.values(row);
+                });
             }
-            else {
-                reject(err);
-            }
-        });
-        link.end();
-    });
-}
+            else
+                throw new Error("No contents in table " + table);
+
+        })
+        .then(function() {
+            link.end();
+            return content;            
+        }).catch(err => { console.error(err); });
+};
 
 module.exports = {
-	csvContents : fileContents,
-	sqlContents : sqlRead
-}
+    csvContents: fileContents,
+    sqlContents: sqlRead
+};

--- a/input/input.js
+++ b/input/input.js
@@ -22,7 +22,8 @@ var sqlRead = function(database, table) {
             host: "localhost",
             port: "3306",
             user: "root",
-            database: database  
+            password: "root",
+            database: database
         })
     );
     var content = [];
@@ -39,7 +40,7 @@ var sqlRead = function(database, table) {
         })
         .then(function() {
             link.end();
-            return content;            
+            return content;
         }).catch(err => { console.error(err); });
 };
 

--- a/input/input.js
+++ b/input/input.js
@@ -1,19 +1,55 @@
 const Promise = require('bluebird');
 const parser = require('./csvParse');
+const mysql = require('mysql');
 const readFile = Promise.promisify(require('fs').readFile);
 
 /*
 * Function fileContents reads the contents of a csv file and parses it
 * @returnType Object of parser class
 */
+
 var fileContents = function(file) {
-	
+
 	return readFile(file,'utf8').then(function(content) {
 		return new parser(content);
 	});
 };
 
 
+var sqlRead = function(database, table) {
+    return new Promise(function(resolve, reject) {
+        var link = mysql.createConnection({
+                        host:'localhost',
+                        port:'3306',
+                        user:'root',
+                        password:'root',
+                        database:database
+                   });
+        link.connect(function(error){
+                     if(error){
+                        console.log(error);
+                     }});
+        link.query("SELECT * FROM "+table, function(err, rows, fields){
+            objs = []
+            if(rows.length !== 0){
+                for(var i = 0;i < rows.length;i++)
+                {
+                    if(table === 'team')
+                        objs.push([rows[i].studentID, rows[i].teamID])
+                    else
+                        objs.push([rows[i].studentID, rows[i].score])
+                }
+                resolve(objs);
+            }
+            else {
+                reject(err);
+            }
+        });
+        link.end();
+    });
+}
+
 module.exports = {
-	csvContents : fileContents
+	csvContents : fileContents,
+	sqlContents : sqlRead
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "bluebird": "^3.5.0",
     "caporal": "^0.7.0",
     "csv": "^1.1.1",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "mysql": "^2.14.1"
   },
   "devDependencies": {
     "chai": "^4.1.1",

--- a/test/eval.test.js
+++ b/test/eval.test.js
@@ -14,8 +14,8 @@ describe("Evaluation", function() {
 		var tempFile = __dirname + "/tempFile.csv";
 
 		var args = {
-			scorescsv: __dirname + "/test_files/scores.csv",
-			teamcsv: __dirname + "/test_files/team.csv",
+			scores: __dirname + "/test_files/scores.csv",
+			teams: __dirname + "/test_files/team.csv", 
 			teamScorescsv: tempFile
 		};
 


### PR DESCRIPTION
@mukkachaitanya I'm pretty sure some more changes have to be made to this PR before merge so please feel free to do them yourself. I will be busy for the next few days.

I wanted the functionality to be like so : 
For CSV read : 
```
node index.js --csvs=<path to team csv>,<path to scores csv>
```
For MySQL read :
```
node index.js --sql=<database name>
```
But `caporal` doesn't seems to be able to break up the `--csvs = team.csv, scores.csv` by using delimiter comma. It would be great if you or @aakp10 could fix this.

@aakp10 Could you also take a look at this and push improvements.

Hopefully closes #3 